### PR TITLE
RFID Access Event API

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,27 @@
+from flask import Flask, request, jsonify
+from services.checkin_service import process_access_event
+
+app = Flask(__name__)
+
+@app.route("/api/access-events", methods=["POST"]) # post requests sent to /api/access-events
+def create_access_event():
+    data = request.get_json() # get the json body from the incoming request
+    if not data: # if no json body, error
+        return jsonify({"error": "Request body must be JSON"}), 400
+
+    # extract fields 
+    card_uid = data.get("card_uid")
+    device_id = data.get("device_id")
+    timestamp = data.get("timestamp")
+
+    # card_uid is required
+    if not card_uid:
+        return jsonify({"error": "card_uid is required"}), 400
+
+    result = process_access_event(
+        card_uid=card_uid,
+        device_id=device_id,
+        timestamp=timestamp
+    )
+    # return the result as a json response with 'OK' http status
+    return jsonify(result), 200

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,8 @@
+import hashlib
+
+def hash_uid(card_uid: str) -> str:
+    """
+    Hash the RFID card UID.
+    """
+    normalized_uid = card_uid.strip()
+    return hashlib.sha256(normalized_uid.encode("utf-8")).hexdigest() # secure hashing technique 

--- a/backend/services/checkin_service.py
+++ b/backend/services/checkin_service.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from app.db import db
+from app.models import Student, AccessEvent
+from app.utils import hash_uid
+
+
+def process_access_event(card_uid: str, device_id: str = None, timestamp: str = None) -> dict:
+    """
+    Process an RFID tap attempt for POST /api/access-events.
+    """
+    card_uid_hash = hash_uid(card_uid)
+    student = Student.query.filter_by(card_uid_hash=card_uid_hash).first() # returns the first match 
+
+    if student != None:
+        decision = "GRANT"
+        reason = "OK"
+        student_id = student.student_id
+    else:
+        decision = "DENY"
+        reason = "NOT_REGISTERED"
+        student_id = None
+
+    if timestamp != None:
+        try:
+            event_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00")) # convert timestamp to python datetime obj.
+        except ValueError: # date is badly formatted
+            event_timestamp = datetime.utcnow() # use current time
+    else:
+        event_timestamp = datetime.utcnow() # if no timestamp exist, use current time
+
+    access_event = AccessEvent( # create a new access event record to log this tap attempt
+
+        student_id=student_id,
+        timestamp=event_timestamp,
+        decision=decision,
+        reason=reason,
+        device_id=device_id,
+        export_status="PENDING"
+    )
+
+    db.session.add(access_event) # add & commit new event to database
+    db.session.commit()
+
+    response = { # response dictionary that will be returned to the Flask route
+        "decision": decision,
+        "reason": reason
+    }
+
+    if student_id: # if a student ID exists, send back final dictionary with that student_id
+        response["student_id"] = student_id
+
+    return response 


### PR DESCRIPTION
RFID Access Event API

Create an API endpoint that processes RFID tap attempts.

Endpoint: POST /api/access-events

Logic:
1. Hash card UID
2. Check if student exists
3. If student exists → GRANT access
4. If not → DENY access (NOT_REGISTERED)
5. Store event in database

Acceptance Criteria
1. Access event saved in database
2. API returns correct response